### PR TITLE
Added support for complexer assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ DerivedData
 Carthage
 
 Pods/
+
+#Jetbrains IDE
+.idea/

--- a/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
+++ b/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
@@ -15,6 +15,13 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
 
     let assetPreview = AssetVideoScrollView()
 
+    /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
+    public var maxDuration: Double = 15 {
+        didSet {
+            assetPreview.maxDuration = maxDuration
+        }
+    }
+
     /// The asset to be displayed in the underlying scroll view. Setting a new asset will automatically refresh the thumbnails.
     public var asset: AVAsset? {
         didSet {

--- a/PryntTrimmerView/Classes/Parents/AssetVideoScrollView.swift
+++ b/PryntTrimmerView/Classes/Parents/AssetVideoScrollView.swift
@@ -14,7 +14,7 @@ class AssetVideoScrollView: UIScrollView {
     private var widthConstraint: NSLayoutConstraint?
 
     let contentView = UIView()
-    var maxDuration: Double = 15
+    public var maxDuration: Double = 15
     private var generator: AVAssetImageGenerator?
 
     override init(frame: CGRect) {
@@ -116,7 +116,6 @@ class AssetVideoScrollView: UIScrollView {
     }
 
     private func getThumbnailTimes(for asset: AVAsset, numberOfThumbnails: Int) -> [NSValue] {
-
         let timeIncrement = (asset.duration.seconds * 1000) / Double(numberOfThumbnails)
         var timesForThumbnails = [NSValue]()
         for index in 0..<numberOfThumbnails {
@@ -128,11 +127,19 @@ class AssetVideoScrollView: UIScrollView {
     }
 
     private func generateImages(for asset: AVAsset, at times: [NSValue], with maximumSize: CGSize, visibleThumnails: Int) {
-
         generator = AVAssetImageGenerator(asset: asset)
-        generator?.appliesPreferredTrackTransform = true
-        let scaledSize = CGSize(width: maximumSize.width * UIScreen.main.scale, height: maximumSize.height *  UIScreen.main.scale)
+        let scaledSize = CGSize(width: maximumSize.width * UIScreen.main.scale, height: maximumSize.height * UIScreen.main.scale)
+        let composition = AVMutableVideoComposition(propertiesOf: asset)
+        var renderSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        for track in asset.tracks where track.mediaType == .video {
+            let size = track.naturalSize
+            if size.width <= renderSize.width && size.height <= renderSize.height {
+                renderSize = size
+            }
+        }
+        composition.renderSize = renderSize
         generator?.maximumSize = scaledSize
+        generator?.videoComposition = composition
         var count = 0
 
         let handler: AVAssetImageGeneratorCompletionHandler = { [weak self] (_, cgimage, _, result, error) in

--- a/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
+++ b/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
@@ -71,13 +71,6 @@ public protocol TrimmerViewDelegate: class {
 
     private let handleWidth: CGFloat = 15
 
-    /// The maximum duration allowed for the trimming. Change it before setting the asset, as the asset preview
-    public var maxDuration: Double = 15 {
-        didSet {
-            assetPreview.maxDuration = maxDuration
-        }
-    }
-
     /// The minimum duration allowed for the trimming. The handles won't pan further if the minimum duration is attained.
     public var minDuration: Double = 3
 


### PR DESCRIPTION
I had some issues with the thumbnail generating in a project I am working on. I changed the logic to use a composition derived from the asset. I also added using the smallest sized video for the generator because when there are multiple video tracks with different sizes some thumbnails come out with the wrong size. I also moved the max duration var to the super class to be able to use that in the same way.

I needed these changes because I am stitching videos together (with the passthrough preset) and rendering the resulting thumbnails. I though the changes might be usable change for the original repo.