### PR TITLE
Prevent constraints from needing to be broken

### DIFF
--- a/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
+++ b/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
@@ -34,23 +34,15 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
 
     func setupSubviews() {
         setupAssetPreview()
-        constrainAssetPreview()
     }
 
     // MARK: - Asset Preview
 
     func setupAssetPreview() {
-
+        self.translatesAutoresizingMaskIntoConstraints = false
         assetPreview.translatesAutoresizingMaskIntoConstraints = false
         assetPreview.delegate = self
         addSubview(assetPreview)
-    }
-
-    func constrainAssetPreview() {
-        assetPreview.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
-        assetPreview.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
-        assetPreview.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        assetPreview.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
     }
 
     func assetDidChange(newAsset: AVAsset?) {

--- a/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
+++ b/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
@@ -84,8 +84,8 @@ public protocol TrimmerViewDelegate: class {
     // MARK: - View & constraints configurations
 
     override func setupSubviews() {
-
         super.setupSubviews()
+        
         backgroundColor = UIColor.clear
         layer.zPosition = 1
         setupTrimmerView()
@@ -97,15 +97,7 @@ public protocol TrimmerViewDelegate: class {
         updateHandleColor()
     }
 
-    override func constrainAssetPreview() {
-        assetPreview.leftAnchor.constraint(equalTo: leftAnchor, constant: handleWidth).isActive = true
-        assetPreview.rightAnchor.constraint(equalTo: rightAnchor, constant: -handleWidth).isActive = true
-        assetPreview.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        assetPreview.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-    }
-
     private func setupTrimmerView() {
-
         trimView.layer.borderWidth = 2.0
         trimView.layer.cornerRadius = 2.0
         trimView.translatesAutoresizingMaskIntoConstraints = false
@@ -118,6 +110,11 @@ public protocol TrimmerViewDelegate: class {
         rightConstraint = trimView.rightAnchor.constraint(equalTo: rightAnchor)
         leftConstraint?.isActive = true
         rightConstraint?.isActive = true
+        
+        assetPreview.leftAnchor.constraint(equalTo: leftAnchor, constant: handleWidth).isActive = true
+        assetPreview.rightAnchor.constraint(equalTo: rightAnchor, constant: -handleWidth).isActive = true
+        assetPreview.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        assetPreview.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
     }
 
     private func setupHandleView() {


### PR DESCRIPTION
There were a couple of warnings in the console that some layouts regarding the width sometimes had to be broken. So I tweaked the code a little such that this issue doesn't occur anymore. This doesn't have a great impact on the project but I was growing weary of those annoying warnings. 