### PR TITLE
Small UI fixes and new options

### DIFF
--- a/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
+++ b/PryntTrimmerView/Classes/Parents/AVAssetTimeSelector.swift
@@ -36,6 +36,12 @@ public class AVAssetTimeSelector: UIView, UIScrollViewDelegate {
         setupAssetPreview()
         constrainAssetPreview()
     }
+  
+    public func regenerateThumbnails() {
+        if let asset = asset {
+            assetPreview.regenerateThumbnails(for: asset)
+        }
+    }
 
     // MARK: - Asset Preview
 

--- a/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
+++ b/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
@@ -86,6 +86,8 @@ public protocol TrimmerViewDelegate: class {
     override func setupSubviews() {
 
         super.setupSubviews()
+        layer.cornerRadius = 2
+        layer.masksToBounds = true
         backgroundColor = UIColor.clear
         layer.zPosition = 1
         setupTrimmerView()

--- a/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
+++ b/PryntTrimmerView/Classes/Trimmer/PryntTrimmerView.swift
@@ -45,6 +45,14 @@ public protocol TrimmerViewDelegate: class {
             positionBar.backgroundColor = positionBarColor
         }
     }
+  
+    /// The color used to mask unselected parts of the video
+    @IBInspectable public var maskColor: UIColor = UIColor.white {
+        didSet {
+            leftMaskView.backgroundColor = maskColor
+            rightMaskView.backgroundColor = maskColor
+        }
+    }
 
     // MARK: Interface
 


### PR DESCRIPTION
This PR includes the following changes: 

• Fixes issue 43# where white corners of the `TrimmerView`'s mask were visible even when the complete clip is selected.

• The color used to mask portions of the video that are not selected are now exposed as properties.

• `AVAssetTimeSelector` has now a public method `regenerateThumbnails()` which triggeres a regeneration of thumbnails if an asset has previously been set. This is useful if a `TrimmerView`'s frame is changed and the previous thumbnails have an invalid size.