### PR TITLE
Swift Package Manager support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PryntTrimmerView",
+    platforms: [.iOS(.v9)],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "PryntTrimmerView",
+            targets: ["PryntTrimmerView"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "PryntTrimmerView",
+            dependencies: [],
+            path: "PryntTrimmerView"),
+    ]
+)


### PR DESCRIPTION
- Package.swift manifest created for SPM support

## Testing

In Xcode 11 use `https://github.com/BalazsSzamody/PryntTrimmerView` path for Adding Swift Package, and use `swift-package` branch instead of `4.0.0` on any project using the library, and remove `PryntTrimmerView` from Podfile