### PR TITLE
Change type casting CMTime to NSValue using NSValue constructor

### DIFF
--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -138,7 +138,7 @@ public class ThumbSelectorView: AVAssetTimeSelector {
 
     private func generateThumbnailImage(for time: CMTime) {
 
-        generator?.generateCGImagesAsynchronously(forTimes: [time as NSValue],
+        generator?.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)],
                                                   completionHandler: { (_, image, _, _, _) in
             guard let image = image else {
                 return


### PR DESCRIPTION
### What is this PR for?
Change type cast CMTime to NSValue using NSValue constructor

### Why are we doing this?
XCode 12.0 beta 6, iOS 14, Swift 5
Fix Compile error "Cannot convert value of type 'CMTime' to type 'NSValue in coercion"

### ScreenShots
<img width="817" alt="스크린샷 2020-08-29 오후 5 03 41" src="https://user-images.githubusercontent.com/25315898/91633138-e92b3f00-ea20-11ea-9bdb-430669f2a990.png">
<img width="453" alt="스크린샷 2020-08-29 오후 6 06 03" src="https://user-images.githubusercontent.com/25315898/91633330-5b505380-ea22-11ea-9779-b46e059abe03.png">