### PR TITLE
Remove deprecated usages of 'class' in protocol definitions.

### DIFF
--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -11,7 +11,7 @@ import AVFoundation
 
 /// A delegate to be notified of when the thumb position has changed. Useful to link an instance of the ThumbSelectorView to a
 /// video preview like an `AVPlayer`.
-public protocol ThumbSelectorViewDelegate: class {
+public protocol ThumbSelectorViewDelegate: AnyObject {
     func didChangeThumbPosition(_ imageTime: CMTime)
 }
 

--- a/Sources/PryntTrimmerView/Trimmer/PryntTrimmerView.swift
+++ b/Sources/PryntTrimmerView/Trimmer/PryntTrimmerView.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 import UIKit
 
-public protocol TrimmerViewDelegate: class {
+public protocol TrimmerViewDelegate: AnyObject {
     func didChangePositionBar(_ playerTime: CMTime)
     func positionBarStoppedMoving(_ playerTime: CMTime)
 }


### PR DESCRIPTION
Using the 'class' keyword in a protocol declaration (eg `protocol MyProtocol : class {}` was deprecated as of Swift 4. I replaced 'class' keyword with 'AnyObject'. This should improve the longevity of the project and remove build warnings for those using Swift 4 and above.