### PR TITLE
Fixed compiler warning about invalid file excludes in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "PryntTrimmerView",
-            exclude: ["PryntTrimmerViewExample", "LICENSE"])
+            exclude: ["../../PryntTrimmerViewExample", "../../LICENSE"])
     ],
     swiftLanguageVersions: [SwiftVersion.v5]
 )


### PR DESCRIPTION
In this PR I updated the `exclude` section of the `Package.swift` to correctly point to the license file and the example project.

Background: as a "home" directory the SPM uses `<package_folder>/Sources/<package_name_folder>` path format, so in our case this is: `PryntTrimmerView/Sources/PryntTrimmerView/`. Therefore SPM tries to find the license and example project over there, however, these items are located **two levels up** in fact — in the package root.

#83 