### PR TITLE
Use `UIApplication` instead of `UIScreen.main` on iOS 13.0 and later

### DIFF
--- a/PryntTrimmerViewExample/VideoCropperViewController.swift
+++ b/PryntTrimmerViewExample/VideoCropperViewController.swift
@@ -51,8 +51,15 @@ class VideoCropperViewController: AssetSelectionViewController {
             var actualTime = CMTime.zero
             let image = try? generator.copyCGImage(at: selectedTime, actualTime: &actualTime)
             if let image = image {
-
-                let selectedImage = UIImage(cgImage: image, scale: UIScreen.main.scale, orientation: .up)
+                var scale: CGFloat = 0
+                
+                if #available(iOS 13.0, *) {
+                    scale = view.window?.windowScene?.screen.scale ?? .zero
+                } else {
+                    scale = UIScreen.main.scale
+                }
+                
+                let selectedImage = UIImage(cgImage: image, scale: scale, orientation: .up)
                 let croppedImage = selectedImage.crop(in: videoCropView.getImageCropFrame())!
                 UIImageWriteToSavedPhotosAlbum(croppedImage, nil, nil, nil)
             }

--- a/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
+++ b/Sources/PryntTrimmerView/Parents/AssetVideoScrollView.swift
@@ -130,7 +130,16 @@ class AssetVideoScrollView: UIScrollView {
         generator = AVAssetImageGenerator(asset: asset)
         generator?.appliesPreferredTrackTransform = true
 
-        let scaledSize = CGSize(width: maximumSize.width * UIScreen.main.scale, height: maximumSize.height * UIScreen.main.scale)
+        var scale: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            scale = windowScene?.screen.scale ?? .zero
+        } else {
+            scale = UIScreen.main.scale
+        }
+        
+        let scaledSize = CGSize(width: maximumSize.width * scale, height: maximumSize.height * scale)
         generator?.maximumSize = scaledSize
         var count = 0
 

--- a/Sources/PryntTrimmerView/ThumbSelectorView.swift
+++ b/Sources/PryntTrimmerView/ThumbSelectorView.swift
@@ -132,7 +132,17 @@ public class ThumbSelectorView: AVAssetTimeSelector {
         let maxDimension = max(assetSize.width, assetSize.height)
         let minDimension = min(assetSize.width, assetSize.height)
         let ratio = maxDimension / minDimension
-        let side = thumbView.frame.height * ratio * UIScreen.main.scale
+        
+        var scale: CGFloat = 0
+        
+        if #available(iOS 13.0, *) {
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            scale = windowScene?.screen.scale ?? .zero
+        } else {
+            scale = UIScreen.main.scale
+        }
+        
+        let side = thumbView.frame.height * ratio * scale
         return CGSize(width: side, height: side)
     }
 


### PR DESCRIPTION
`UIScree.main` will be deprecated in a future version of iOS.
I used `UIAplication` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `UIApplication` is the one way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.